### PR TITLE
normalize root path for use on all OS's

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@
 var assert = require('assert');
 var debug = require('debug')('koa-static');
 var send = require('koa-send');
+var path = require('path');
 
 /**
  * Expose `serve()`.
@@ -29,7 +30,7 @@ function serve(root, opts) {
 
   // options
   debug('static "%s" %j', root, opts);
-  opts.root = root;
+  opts.root = path.normalize(root);
   opts.index = opts.index || 'index.html';
 
   if (!opts.defer) {


### PR DESCRIPTION
Hi, this commit fixes the problem when using koa-static's example code on Windows (this currently gives "malicious path" errors).
Windows uses a different path-seperator, which is fixed by using `path.normalize(root)` inside the `serve()` method.
