### PR TITLE
Revert "normalize root path for use on all OS's"

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@
 var assert = require('assert');
 var debug = require('debug')('koa-static');
 var send = require('koa-send');
-var path = require('path');
 
 /**
  * Expose `serve()`.
@@ -30,7 +29,7 @@ function serve(root, opts) {
 
   // options
   debug('static "%s" %j', root, opts);
-  opts.root = path.normalize(root);
+  opts.root = root;
   opts.index = opts.index || 'index.html';
 
   if (!opts.defer) {


### PR DESCRIPTION
This reverts commit f05c05f10635f0c2d313b6807f58bb044c47d1ca.

When looking into koa-send, I found out the source of this problem was already fixed by Jonathan Ong 4 days ago (see koajs/send@7ba7cc3) so my commit here should be reverted, because it's superfluous.
