### PR TITLE
Fix already handled logic for koa default status == 404

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,9 @@
 
+1.4.5 / 2014-05-05
+==================
+
+ * Fix response already handled logic - Koajs now defaults status == 404. See  koajs/koa#269
+
 1.4.4 / 2014-05-04
 ==================
 

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function serve(root, opts) {
     yield next;
 
     // response is already handled
-    if (!this.idempotent || this.body != null || this.status != null) return;
+    if (!this.idempotent || this.body != null || this.status != 404) return;
 
     yield send(this, this.path, opts);
   };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "koa-static",
   "description": "Static file serving middleware for koa",
   "repository": "koajs/static",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "keywords": [
     "koa",
     "middleware",


### PR DESCRIPTION
Koajs now defaults status == 404. See  koajs/koa#269
