### PR TITLE
Add callback option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,6 +33,7 @@ app.use(require('koa-static')(root, opts));
  - `hidden` Allow transfer of hidden files. defaults to false
  - `index` Default file name, defaults to 'index.html'
  - `defer` If true, serves after `yield next`, allowing any downstream middleware to respond first.
+ - `callback(ctx, path)` A regular function or generator function, invoked when serving a static file.
 
 ## Example
 

--- a/Readme.md
+++ b/Readme.md
@@ -33,7 +33,7 @@ app.use(require('koa-static')(root, opts));
  - `hidden` Allow transfer of hidden files. defaults to false
  - `index` Default file name, defaults to 'index.html'
  - `defer` If true, serves after `yield next`, allowing any downstream middleware to respond first.
- - `callback(ctx, path)` A regular function or generator function, invoked when serving a static file.
+ - `callback(ctx, path)` The regular function or the generator function, invoked when serving a static file.
 
 ## Example
 

--- a/index.js
+++ b/index.js
@@ -36,7 +36,18 @@ function serve(root, opts) {
   if (!opts.defer) {
     return function *serve(next){
       if (this.method == 'HEAD' || this.method == 'GET') {
-        if (yield send(this, this.path, opts)) return;
+        var path = yield send(this, this.path, opts)
+        if (path) {
+          if (typeof opts.callback==='function') {
+            if (opts.callback.constructor.name === 'GeneratorFunction') {
+              yield opts.callback(this, path);
+            }
+            else {
+              opts.callback(this, path);
+            }
+          }
+          return;
+        }
       }
       yield* next;
     };

--- a/index.js
+++ b/index.js
@@ -38,14 +38,7 @@ function serve(root, opts) {
       if (this.method == 'HEAD' || this.method == 'GET') {
         var path = yield send(this, this.path, opts)
         if (path) {
-          if (typeof opts.callback==='function') {
-            if (opts.callback.constructor.name === 'GeneratorFunction') {
-              yield opts.callback(this, path);
-            }
-            else {
-              opts.callback(this, path);
-            }
-          }
+          yield invokeCallback(this, path);
           return;
         }
       }
@@ -60,6 +53,20 @@ function serve(root, opts) {
     // response is already handled
     if (this.body != null || this.status != 404) return;
 
-    yield send(this, this.path, opts);
+    var path = yield send(this, this.path, opts);
+    yield invokeCallback(this, path);
   };
+
+  function *invokeCallback(ctx, path) {
+    if (path) {
+      if (typeof opts.callback==='function') {
+        if (opts.callback.constructor.name === 'GeneratorFunction') {
+          yield opts.callback(ctx, path);
+        }
+        else {
+          opts.callback(ctx, path);
+        }
+      }
+    }
+  }
 }

--- a/index.js
+++ b/index.js
@@ -58,14 +58,12 @@ function serve(root, opts) {
   };
 
   function *invokeCallback(ctx, path) {
-    if (path) {
-      if (typeof opts.callback==='function') {
-        if (opts.callback.constructor.name === 'GeneratorFunction') {
-          yield opts.callback(ctx, path);
-        }
-        else {
-          opts.callback(ctx, path);
-        }
+    if (path && typeof opts.callback==='function') {
+      if (opts.callback.constructor.name === 'GeneratorFunction') {
+        yield opts.callback(ctx, path);
+      }
+      else {
+        opts.callback(ctx, path);
       }
     }
   }

--- a/test/index.js
+++ b/test/index.js
@@ -103,11 +103,25 @@ describe('serve(root)', function(){
     })
 
     describe('when callback is specified', function(){
-      it('should perform callback', function(done){
+      it('should perform generator function callback', function(done){
         var app = koa();
 
         app.use(serve('test/fixtures', {
           callback: function*(ctx, path) {
+            ctx.body = path;
+          }
+        }));
+
+        request(app.listen())
+        .get('/hello.txt')
+        .expect(200)
+        .expect(__dirname + '/fixtures/hello.txt', done);
+      })
+      it('should perform regular function callback', function(done){
+        var app = koa();
+
+        app.use(serve('test/fixtures', {
+          callback: function(ctx, path) {
             ctx.body = path;
           }
         }));
@@ -288,6 +302,21 @@ describe('serve(root)', function(){
         app.use(serve('test/fixtures', {
           defer: true,
           callback: function*(ctx, path) {
+            ctx.body = path;
+          }
+        }));
+
+        request(app.listen())
+        .get('/hello.txt')
+        .expect(200)
+        .expect(__dirname + '/fixtures/hello.txt', done);
+      })
+      it('should perform regular function callback', function(done){
+        var app = koa();
+
+        app.use(serve('test/fixtures', {
+          defer: true,
+          callback: function(ctx, path) {
             ctx.body = path;
           }
         }));

--- a/test/index.js
+++ b/test/index.js
@@ -281,6 +281,24 @@ describe('serve(root)', function(){
       })
     })
 
+    describe('when callback is specified', function(){
+      it('should perform callback', function(done){
+        var app = koa();
+
+        app.use(serve('test/fixtures', {
+          defer: true,
+          callback: function*(ctx, path) {
+            ctx.body = path;
+          }
+        }));
+
+        request(app.listen())
+        .get('/hello.txt')
+        .expect(200)
+        .expect(__dirname + '/fixtures/hello.txt', done);
+      })
+    })
+
   })
 
 })

--- a/test/index.js
+++ b/test/index.js
@@ -101,6 +101,24 @@ describe('serve(root)', function(){
         .expect(404, done);
       })
     })
+
+    describe('when callback is specified', function(){
+      it('should perform callback', function(done){
+        var app = koa();
+
+        app.use(serve('test/fixtures', {
+          callback: function*(ctx, path) {
+            ctx.body = path;
+          }
+        }));
+
+        request(app.listen())
+        .get('/hello.txt')
+        .expect(200)
+        .expect(__dirname + '/fixtures/hello.txt', done);
+      })
+    })
+
   })
 
   describe('when defer: true', function(){
@@ -262,5 +280,7 @@ describe('serve(root)', function(){
         .expect(404, done);
       })
     })
+
   })
+
 })


### PR DESCRIPTION
This adds callback option to koa-static so that you can perform additional processing such as setting custom headers for the static assets.