### PR TITLE
Directories without a trailing slash #31

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,6 +33,7 @@ app.use(require('koa-static')(root, opts));
  - `hidden` Allow transfer of hidden files. defaults to false
  - `index` Default file name, defaults to 'index.html'
  - `defer` If true, serves after `yield next`, allowing any downstream middleware to respond first.
+ - `format` If true, format the path to serve static file servers and not require a trailing slash for directories, so that you can do both `/directory` and `/directory/`
 
 ## Example
 

--- a/index.js
+++ b/index.js
@@ -56,11 +56,11 @@ function serve(root, opts) {
   // and not require a trailing slash for directories,
   // so that you can do both `/directory` and `/directory/`
   function formatPath(path) {
-    if (opts.disableFormat) {
-      return path;
-    } else {
+    if (opts.format) {
       var trailingSlash = '/' == path[path.length - 1];
       return trailingSlash ? path : path + '/';
+    } else {
+      return path;
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function serve(root, opts) {
   if (!opts.defer) {
     return function *serve(next){
       if (this.method == 'HEAD' || this.method == 'GET') {
-        if (yield send(this, this.path, opts)) return;
+        if (yield send(this, formatPath(this.path), opts)) return;
       }
       yield* next;
     };
@@ -49,6 +49,18 @@ function serve(root, opts) {
     // response is already handled
     if (this.body != null || this.status != 404) return;
 
-    yield send(this, this.path, opts);
+    yield send(this, formatPath(this.path), opts);
   };
+
+  // Format the path to serve static file servers
+  // and not require a trailing slash for directories,
+  // so that you can do both `/directory` and `/directory/`
+  function formatPath(path) {
+    if (opts.disableFormat) {
+      return path;
+    } else {
+      var trailingSlash = '/' == path[path.length - 1];
+      return trailingSlash ? path : path + '/';
+    }
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -262,5 +262,34 @@ describe('serve(root)', function(){
         .expect(404, done);
       })
     })
+
+    describe('when format: true', function() {
+      it('should send the html page', function (done) {
+        var app = koa();
+
+        app.use(serve('test/fixtures', {
+          format: true
+        }));
+
+        request(app.listen())
+          .get('/world')
+          .expect(200)
+          .expect('html index', done);
+      })
+    })
+
+    describe('when format: false', function() {
+      it('should 404', function (done) {
+        var app = koa();
+
+        app.use(serve('test/fixtures', {
+          format: false
+        }));
+
+        request(app.listen())
+          .get('/world')
+          .expect(404, done);
+      })
+    })
   })
 })


### PR DESCRIPTION
Format the path to serve static file servers and not require a trailing slash for directories, so that you can do both `/directory` and `/directory/`.