### PR TITLE
Updated README.md for koa as a constructor (next)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,8 +18,8 @@ $ npm install koa-static
 ## API
 
 ```js
-var koa = require('koa');
-var app = koa();
+var Koa = require('koa');
+var app = new Koa();
 app.use(require('koa-static')(root, opts));
 ```
 
@@ -38,8 +38,8 @@ app.use(require('koa-static')(root, opts));
 
 ```js
 var serve = require('koa-static');
-var koa = require('koa');
-var app = koa();
+var Koa = require('koa');
+var app = new Koa();
 
 // $ GET /package.json
 app.use(serve('.'));


### PR DESCRIPTION
In koa v2, koa itself is a constructor and must be run with new.