### PR TITLE
fix `index: false` bug if path is directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,8 +39,7 @@ function serve (root, opts) {
     return async function serve (ctx, next) {
       if (ctx.method === 'HEAD' || ctx.method === 'GET') {
         try {
-          const path = await send(ctx, ctx.path, opts)
-          path || await next()
+          await send(ctx, ctx.path, opts)
         } catch (err) {
           await next()
         }

--- a/index.js
+++ b/index.js
@@ -39,7 +39,8 @@ function serve (root, opts) {
     return async function serve (ctx, next) {
       if (ctx.method === 'HEAD' || ctx.method === 'GET') {
         try {
-          await send(ctx, ctx.path, opts)
+          const path = await send(ctx, ctx.path, opts)
+          path || await next()
         } catch (err) {
           await next()
         }

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function serve (root, opts) {
     return async function serve (ctx, next) {
       if (ctx.method === 'HEAD' || ctx.method === 'GET') {
         try {
-          await send(ctx, ctx.path, opts)
+          await send(ctx, ctx.path, opts) || await next()
         } catch (err) {
           await next()
         }

--- a/test/index.js
+++ b/test/index.js
@@ -132,6 +132,19 @@ describe('serve(root)', function () {
             .get('/world/')
             .expect(404, done)
         })
+
+        it('should pass to downstream if 404', function (done) {
+          const app = new Koa()
+
+          app.use(serve('test/fixtures', { index: false }))
+          app.use(async (ctx) => {
+            ctx.body = 'oh no'
+          })
+
+          request(app.listen())
+            .get('/world/')
+            .expect('oh no', done)
+        })
       })
     })
 

--- a/test/index.js
+++ b/test/index.js
@@ -132,19 +132,6 @@ describe('serve(root)', function () {
             .get('/world/')
             .expect(404, done)
         })
-
-        it('should pass to downstream if 404', function (done) {
-          const app = new Koa()
-
-          app.use(serve('test/fixtures', { index: false }))
-          app.use(async (ctx) => {
-            ctx.body = 'oh no'
-          })
-
-          request(app.listen())
-            .get('/world/')
-            .expect('oh no', done)
-        })
       })
     })
 


### PR DESCRIPTION
If `index: false`, and path is directory, it should be able to pass to downstream middleware.

Here's a test snippet:

```js
it('should pass to downstream', function (done) {
  const app = new Koa()

  app.use(serve('test/fixtures', { index: false }))
  app.use(async (ctx) => {
    ctx.body = 'oh no'
  })

  request(app.listen())
    .get('/world/')
    .expect('oh no', done)
})
```

Result is:
```
Error: expected 'oh no' response body, got 'Not Found'
```