### PR TITLE
fix: `serve` mutates `opts` argument so it cannot be reused

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = serve
  */
 
 function serve (root, opts) {
-  opts = opts || {}
+  opts = Object.assign({}, opts || {})
 
   assert(root, 'root directory is required to serve files')
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = serve
  */
 
 function serve (root, opts) {
-  opts = Object.assign({}, opts || {})
+  opts = Object.assign({}, opts)
 
   assert(root, 'root directory is required to serve files')
 


### PR DESCRIPTION
Thanks for your work with this module! I noticed a small issue when trying to reuse the options object:

```javascript
const Koa = require('koa');
const serve = require('koa-static');

const app = new Koa();
const options = { maxage: 30 * 24 * 60 * 60 };

app
	.use(serve('./dir1', options))
	.use(serve('./dir2', options));
```

When using the same options object for more than one call to `serve`, only the last directory will be served - in the above example, only "dir2".