### PR TITLE
update readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,6 +33,7 @@ app.use(require('koa-static')(root, opts));
  - `index` Default file name, defaults to 'index.html'
  - `defer` If true, serves after `return next()`, allowing any downstream middleware to respond first.
  - `gzip`  Try to serve the gzipped version of a file automatically when gzip is supported by a client and if the requested file with .gz extension exists. defaults to true.
+ - `br`  Try to serve the brotli version of a file automatically when brotli is supported by a client and if the requested file with .br extension exists (note, that brotli is only accepted over https). defaults to true.
  - [setHeaders](https://github.com/koajs/send#setheaders) Function to set custom headers on response.
  - `extensions` Try to match extensions from passed array to search for file when no extension is sufficed in URL. First found is served. (defaults to `false`)
 


### PR DESCRIPTION
I just refer on https://github.com/koajs/send 

at first I wanted to write issue:  why not working sending brotli. As it turned out, koa-send works fine and even raises the priority to `.br`. It's all browser conventional requirement of https.