### PR TITLE
Adds secondary "legacy" Node v6 Support via Babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,9 @@
+{
+  "presets": [
+    ["@babel/preset-env", {
+      "targets": {
+        "node": "6.11"
+      }
+    }]
+  ]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -5,5 +5,13 @@
         "node": "6.11"
       }
     }]
+  ],
+  "plugins": [
+    ["module-resolver", {
+      "root": [""],
+      "alias": {
+        "koa-send": "koa-send/legacy"
+      }
+    }]
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 package-lock.json
 node_modules
 coverage
+legacy/*.js

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "sendfile"
   ],
   "files": [
-    "index.js"
+    "index.js",
+    "legacy/index.js"
   ],
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.39",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "babel-plugin-module-resolver": "^3.0.0",
     "debug": "^2.6.8",
     "koa-send": "^4.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "index.js"
   ],
   "devDependencies": {
+    "@babel/cli": "^7.0.0-beta.39",
+    "@babel/core": "^7.0.0-beta.39",
+    "@babel/polyfill": "^7.0.0-beta.39",
+    "@babel/preset-env": "^7.0.0-beta.39",
+    "@babel/register": "^7.0.0-beta.39",
     "eslint": "^4.1.1",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.6.1",
@@ -32,6 +37,7 @@
   },
   "scripts": {
     "lint": "eslint --fix .",
+    "prepublishOnly": "babel index.js --out-file legacy/index.js",
     "test": "mocha --harmony --reporter spec",
     "test-cov": "node --harmony ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha",
     "test-travis": "node --harmony ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --report lcovonly"


### PR DESCRIPTION
In follow-up to #123 and due to a blocking issue with `@babel/register` in [webpack-serve](/webpack-contrib/webpack-serve), I put this PR together. Apologies for not waiting on an answer, but the blocking issue with Babel was holding a beta release of that module up, and the only clear solution was to roll out user-scoped versions of `koa-static` and `koa-send` that allow Node v6 support. 

This PR changes a few things:

- adds a `.babelrc` file with the correct configuration to produce output for Node v6.
- adds `prepublishOnly` script to automatically create the `legacy/index.js` file for publish.
- rewrites `require('koa-send')` to `require('koa-send/legacy')` in the output.

So as not to imply direct support of Node v6 I did not change the `engines` property in package.json. 

I'll add a PR for `koa-send` shortly which adds much of the same, as both modules need to be modified in this way to work properly on Node v6. For anyone needing this support immediately, you can use my user-scoped module here: [https://www.npmjs.com/package/@shellscape/koa-static](https://www.npmjs.com/package/@shellscape/koa-static)