### PR TITLE
feat: use create null to optimize

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = serve
  */
 
 function serve (root, opts) {
-  opts = Object.assign({}, opts)
+  opts = Object.assign(Object.create(null), opts)
 
   assert(root, 'root directory is required to serve files')
 


### PR DESCRIPTION
`Object.create(null)` is better than `{}`. It has no prototype,  and reduce memory footprint.