### PR TITLE
Redirect directory requests missing trailing slash

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,6 +34,7 @@ app.use(serve(root, opts));
 - `defer` If true, serves after `return next()`, allowing any downstream middleware to respond first.
 - `gzip` Try to serve the gzipped version of a file automatically when gzip is supported by a client and if the requested file with .gz extension exists. defaults to true.
 - `brotli` Try to serve the brotli version of a file automatically when brotli is supported by a client and if the requested file with .br extension exists (note, that brotli is only accepted over https). defaults to true.
+- `format` Directory handling mode. By default, directory requests without a trailing slash redirect to the slash-appended URL when an index file exists. If `true`, directory indexes are served without requiring a trailing slash. If `false`, directory index formatting is disabled.
 - [setHeaders](https://github.com/koajs/send#setheaders) Function to set custom headers on response.
 - `extensions` Try to match extensions from passed array to search for file when no extension is sufficed in URL. First found is served. (defaults to `false`).  e.g. `['html']`
 

--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ function getSearch (ctx) {
 }
 
 function resolveFromRoot (root, pathname) {
-  const filename = pathname.substr(path.parse(pathname).root.length)
+  const filename = pathname.slice(path.parse(pathname).root.length)
   const resolved = path.resolve(root, filename)
   const relative = path.relative(root, resolved)
 

--- a/index.js
+++ b/index.js
@@ -70,6 +70,7 @@ function serve (root, opts = {}) {
 }
 
 async function redirectToDirectorySlash (ctx, opts) {
+  if (ctx.method !== 'HEAD' && ctx.method !== 'GET') return false
   if (!opts.index || ctx.path[ctx.path.length - 1] === '/') return false
   if (opts.format !== undefined && opts.format !== 'redirect') return false
 
@@ -98,7 +99,7 @@ async function redirectToDirectorySlash (ctx, opts) {
 
   if (!stats.isFile()) return false
 
-  ctx.redirect(ctx.path + '/' + ctx.search)
+  ctx.redirect(ctx.path + '/' + getSearch(ctx))
   return true
 }
 
@@ -122,6 +123,13 @@ function isHidden (root, pathname) {
 
 function isNotFound (err) {
   return err.code === 'ENOENT' || err.code === 'ENOTDIR' || err.code === 'ENAMETOOLONG'
+}
+
+function getSearch (ctx) {
+  const search = ctx.search
+
+  if (!search) return ''
+  return search[0] === '?' ? search : `?${search}`
 }
 
 function resolveFromRoot (root, pathname) {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 'use strict'
 
 /**
@@ -6,6 +5,7 @@
  */
 
 const debug = require('debug')('koa-static')
+const fs = require('fs')
 const path = require('path')
 const assert = require('assert')
 const send = require('koa-send')
@@ -38,7 +38,7 @@ function serve (root, opts = {}) {
 
       if (ctx.method === 'HEAD' || ctx.method === 'GET') {
         try {
-          done = await send(ctx, ctx.path, opts)
+          done = await redirectToDirectorySlash(ctx, opts) || await send(ctx, ctx.path, opts)
         } catch (err) {
           if (err.status !== 404) {
             throw err
@@ -60,11 +60,78 @@ function serve (root, opts = {}) {
     if (ctx.body != null || ctx.status !== 404) return // eslint-disable-line
 
     try {
-      await send(ctx, ctx.path, opts)
+      await redirectToDirectorySlash(ctx, opts) || await send(ctx, ctx.path, opts)
     } catch (err) {
       if (err.status !== 404) {
         throw err
       }
     }
   }
+}
+
+async function redirectToDirectorySlash (ctx, opts) {
+  if (!opts.index || ctx.path[ctx.path.length - 1] === '/') return false
+  if (opts.format !== undefined && opts.format !== 'redirect') return false
+
+  const pathname = decode(ctx.path)
+  if (pathname === -1 || pathname.indexOf('\0') !== -1) return false
+
+  const dir = resolveFromRoot(opts.root, pathname)
+  if (!dir || (!opts.hidden && isHidden(opts.root, dir))) return false
+
+  let stats
+  try {
+    stats = await fs.promises.stat(dir)
+  } catch (err) {
+    if (isNotFound(err)) return false
+    throw err
+  }
+
+  if (!stats.isDirectory()) return false
+
+  try {
+    stats = await fs.promises.stat(path.join(dir, opts.index))
+  } catch (err) {
+    if (isNotFound(err)) return false
+    throw err
+  }
+
+  if (!stats.isFile()) return false
+
+  ctx.redirect(ctx.path + '/' + ctx.search)
+  return true
+}
+
+function decode (pathname) {
+  try {
+    return decodeURIComponent(pathname)
+  } catch (err) {
+    return -1
+  }
+}
+
+function isHidden (root, pathname) {
+  const parts = path.relative(root, pathname).split(path.sep)
+
+  for (let i = 0; i < parts.length; i++) {
+    if (parts[i][0] === '.') return true
+  }
+
+  return false
+}
+
+function isNotFound (err) {
+  return err.code === 'ENOENT' || err.code === 'ENOTDIR' || err.code === 'ENAMETOOLONG'
+}
+
+function resolveFromRoot (root, pathname) {
+  const filename = pathname.substr(path.parse(pathname).root.length)
+  const resolved = path.resolve(root, filename)
+  const relative = path.relative(root, resolved)
+
+  if (relative === '' || (relative.substr(0, 2) !== '..' && !path.isAbsolute(relative))) {
+    return resolved
+  }
+
+  return null
 }

--- a/test/fixtures/empty/hello.txt
+++ b/test/fixtures/empty/hello.txt
@@ -1,0 +1,1 @@
+empty fixture

--- a/test/index.js
+++ b/test/index.js
@@ -126,6 +126,17 @@ describe('serve(root)', function () {
           app.use(serve('test/fixtures'))
 
           request(app.listen())
+            .get('/world')
+            .expect(302)
+            .expect('Location', '/world/', done)
+        })
+
+        it('should preserve the query string when redirecting a directory request', function (done) {
+          const app = new Koa()
+
+          app.use(serve('test/fixtures'))
+
+          request(app.listen())
             .get('/world?foo=bar')
             .expect(302)
             .expect('Location', '/world/?foo=bar', done)
@@ -377,6 +388,21 @@ describe('serve(root)', function () {
 
         request(app.listen())
           .post('/hello.txt')
+          .expect(404, done)
+      })
+
+      it('should not redirect directory requests', function (done) {
+        const app = new Koa()
+
+        app.use(serve('test/fixtures', {
+          defer: true
+        }))
+
+        request(app.listen())
+          .post('/world')
+          .expect((res) => {
+            assert.equal(res.headers.location, undefined)
+          })
           .expect(404, done)
       })
     })

--- a/test/index.js
+++ b/test/index.js
@@ -274,6 +274,21 @@ describe('serve(root)', function () {
             .expect(302)
             .expect('Location', '/world/?foo=bar', done)
         })
+
+        it('should not redirect when the directory has no index file', function (done) {
+          const app = new Koa()
+
+          app.use(serve('test/fixtures', {
+            defer: true
+          }))
+
+          request(app.listen())
+            .get('/empty?foo=bar')
+            .expect((res) => {
+              assert.equal(res.headers.location, undefined)
+            })
+            .expect(404, done)
+        })
       })
     })
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,3 @@
-
 'use strict'
 
 const request = require('supertest')
@@ -120,6 +119,27 @@ describe('serve(root)', function () {
             .expect('Content-Type', 'text/html; charset=utf-8')
             .expect('html index', done)
         })
+
+        it('should redirect directory requests missing a trailing slash', function (done) {
+          const app = new Koa()
+
+          app.use(serve('test/fixtures'))
+
+          request(app.listen())
+            .get('/world?foo=bar')
+            .expect(302)
+            .expect('Location', '/world/?foo=bar', done)
+        })
+
+        it('should not redirect when the directory has no index file', function (done) {
+          const app = new Koa()
+
+          app.use(serve('test/fixtures'))
+
+          request(app.listen())
+            .get('/empty')
+            .expect(404, done)
+        })
       })
 
       describe('when disabled', function () {
@@ -229,6 +249,19 @@ describe('serve(root)', function () {
             .expect(200)
             .expect('Content-Type', 'text/html; charset=utf-8')
             .expect('html index', done)
+        })
+
+        it('should redirect directory requests missing a trailing slash', function (done) {
+          const app = new Koa()
+
+          app.use(serve('test/fixtures', {
+            defer: true
+          }))
+
+          request(app.listen())
+            .get('/world?foo=bar')
+            .expect(302)
+            .expect('Location', '/world/?foo=bar', done)
         })
       })
     })


### PR DESCRIPTION
Fixes #130.

This adds a guarded directory redirect before delegating to `koa-send`: when a GET/HEAD request targets a directory without a trailing slash and the configured index file exists, `koa-static` redirects to the slash-appended URL while preserving the query string.

The change keeps the existing explicit options intact:
- `format: true` still serves `/dir` directly.
- `format: false` still disables directory index formatting.
- directories without an index file do not redirect.

Verification:
- `npm test`
- `npm run lint`
- `git diff --check`

## Summary by Sourcery

Handle directory requests without trailing slashes by redirecting to the slash-appended URL when an index file exists, while preserving existing directory handling modes.

New Features:
- Add guarded redirect for GET/HEAD directory requests missing a trailing slash when an index file exists, preserving the query string.

Documentation:
- Document the new `format` option behavior for directory request handling modes.

Tests:
- Add tests covering redirect behavior for directory requests without trailing slash in both standard and `defer` modes, including cases without an index file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Directory requests missing a trailing slash now optionally redirect to the slash-suffixed path (preserves query strings); behavior is controlled by the new format option.

* **Bug Fixes**
  * Redirects only occur for GET/HEAD and when a directory index exists; directories without an index return 404.

* **Documentation**
  * API docs updated to describe the new format option and directory handling.

* **Tests**
  * Added tests covering redirect behavior, query-string preservation, and non-redirect cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->