### PR TITLE
chore: add homepage and bugs URLs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,9 @@
   },
   "engines": {
     "node": ">= 14"
+  },
+  "homepage": "https://github.com/koajs/static",
+  "bugs": {
+    "url": "https://github.com/koajs/static/issues"
   }
 }


### PR DESCRIPTION
Adds `homepage` and `bugs.url` fields to package.json so users can easily find the project website and report issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project metadata to include official homepage and issue-reporting links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->